### PR TITLE
Fix Makefile: Move -lpthread from LDFLAGS to LIBS

### DIFF
--- a/h264enc/Makefile
+++ b/h264enc/Makefile
@@ -1,8 +1,8 @@
 TARGET = h264enc
 SRC = main.c h264enc.c ../common/ve.c
 CFLAGS = -Wall -O3 -I../common
-LDFLAGS = -lpthread
-LIBS =
+LDFLAGS =
+LIBS = -lpthread
 CC = gcc
 
 MAKEFLAGS += -rR --no-print-directory


### PR DESCRIPTION
Some gcc versions get error: "undefined reference to 'pthread_rwlock_wrlock'" when -lpthread is set in LDFLAGS of Makefile.